### PR TITLE
Short read processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # nextflow-fastq-alignment
-Repository for aligning specified FASTQ reads from M. tuberculosis samples to a reference genome
+Repository for aligning specified FASTQ reads from M. tuberculosis samples to a reference genome. Supported are long reads (ONT-Nanopore) and paired short reads (Illumina).
+
+**Installation**
+```
+git clone <repository-url>
+cd nextflow-fastq-alignment
+```
+
+**Usage**
+```
+# Short reads (Illumina paired-end)
+nextflow run read_alignment_pipeline.nf \
+    --readType short \
+    --inputFastq ./fastq_files \
+    --referenceFasta ./reference.fasta \
+    [--outputPrefix 'sample1'] \
+    [--outputDir .results]
+
+# Long reads (Nanopore)
+nextflow run read_alignment_pipeline.nf \
+    --readType long \
+    --inputFastq ./fastq_files \
+    --referenceFasta ./reference.fasta \
+    [--outputPrefix 'sample1'] \
+    [--outputDir .results]
+```
+
+**Pipeline structure**
+| Step  | Tool for short reads | Tool for long reads |
+| ------------- | ------------- |
+| Alignment  | minimap2 `-ax sr`  | minimap2 `-ax map-ont` |
+| Variant Calling  | FreeBayes  | longshot |
+| Consensus  | bcftools consensus  | bcftools consensus |
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # nextflow-fastq-alignment
-Repository for aligning specified FASTQ reads from M. tuberculosis samples to a reference genome. Supported are long reads (ONT-Nanopore) and paired short reads (Illumina).
+Repository for aligning specified FASTQ reads from M. tuberculosis samples to a reference genome. Supported are long reads (ONT-Nanopore) and paired short reads (Illumina). Requires Nextflow and Conda to be installed.
 
 **Installation**
 ```
-git clone <repository-url>
+git clone https://github.com/viktoria023/nextflow-fastq-alignment.git
 cd nextflow-fastq-alignment
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nextflow run read_alignment_pipeline.nf \
 
 **Pipeline structure**
 | Step  | Tool for short reads | Tool for long reads |
-| ------------- | ------------- |
+| ------------- | ------------- | ------------- |
 | Alignment  | minimap2 `-ax sr`  | minimap2 `-ax map-ont` |
 | Variant Calling  | FreeBayes  | longshot |
 | Consensus  | bcftools consensus  | bcftools consensus |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ nextflow run read_alignment_pipeline.nf \
     --inputFastq ./fastq_files \
     --referenceFasta ./reference.fasta \
     [--outputPrefix 'sample1'] \
-    [--outputDir .results]
+    [--outputDir ./results]
 
 # Long reads (Nanopore)
 nextflow run read_alignment_pipeline.nf \
@@ -23,7 +23,22 @@ nextflow run read_alignment_pipeline.nf \
     --inputFastq ./fastq_files \
     --referenceFasta ./reference.fasta \
     [--outputPrefix 'sample1'] \
-    [--outputDir .results]
+    [--outputDir ./results]
+```
+
+**Input file structure**
+
+Short reads
+```
+fastq_files/
+├── sample1_1.fastq.gz
+└── sample1_2.fastq.gz
+```
+
+Long reads
+```
+fastq_files/
+└── sample1.fastq.gz
 ```
 
 **Pipeline structure**

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,13 @@
 name: mtb-consensus
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
 dependencies:
   - python=3.9
   - nextflow
   - minimap2
   - samtools>=1.17
   - bcftools>=1.17
+  - freebayes
   - longshot
   - htslib>=1.17

--- a/modules/align.nf
+++ b/modules/align.nf
@@ -1,6 +1,6 @@
 process ALIGN {
     tag "${sample}"
-    cpus 4
+    cpus 8
     publishDir "${params.outputDir}/alignments", mode: 'copy'
 
     input:
@@ -11,9 +11,17 @@ process ALIGN {
     tuple val(sample), path("${sample}.aligned.bam"), path("${sample}.aligned.bam.bai"), emit: bam
 
     script:
+    def preset = params.readType == "short" ? "sr" : "map-ont"
+    def read_input = ""
+
+    if (params.readType == "short") {
+        read_input = "${reads[0]} ${reads[1]}"
+    } else {
+        read_input = "${reads}"
+    }
     """
-    # Align reads using minimap2 and sort
-    minimap2 -ax map-ont -t ${task.cpus} ${reference} ${reads} | \\
+    # Align reads using minimap2 using the preset for short or long reads
+    minimap2 -ax ${preset} -t ${task.cpus} ${reference} ${read_input} | \\
         samtools sort -@ ${task.cpus} -o ${sample}.aligned.bam -
 
     # Index the BAM file

--- a/modules/align.nf
+++ b/modules/align.nf
@@ -1,6 +1,5 @@
 process ALIGN {
     tag "${sample}"
-    cpus 8
     publishDir "${params.outputDir}/alignments", mode: 'copy'
 
     input:

--- a/modules/consensus.nf
+++ b/modules/consensus.nf
@@ -1,6 +1,5 @@
 process GENERATE_CONSENSUS {
     tag "${sample}"
-    cpus 4
     publishDir "${params.outputDir}/consensus", mode: 'copy'
 
     input:

--- a/modules/variants_long.nf
+++ b/modules/variants_long.nf
@@ -1,6 +1,5 @@
-process CALL_VARIANTS {
+process CALL_VARIANTS_LONG {
     tag "${sample}"
-    cpus 8
     publishDir "${params.outputDir}/variants", mode: 'copy'
 
     input:

--- a/modules/variants_short.nf
+++ b/modules/variants_short.nf
@@ -1,0 +1,30 @@
+process CALL_VARIANTS_SHORT {
+    tag "${sample}"
+    publishDir "${params.outputDir}/variants", mode: 'copy', pattern: "*.bam*"
+
+    input:
+    tuple val(sample), path(bam), path(bai)
+    path reference
+
+    output:
+    tuple val(sample), path("${sample}.variants.vcf"), emit: vcf
+
+    script:
+    """
+    # Index the FASTA reference file
+    samtools faidx ${reference}
+
+    # Call variants with freebayes
+    freebayes -f ${reference} \\
+    --ploidy 1 \\
+    --min-base-quality 20 \\
+    --min-mapping-quality 30 \\
+    --min-coverage 10 \\
+    ${bam} > ${sample}.variants.vcf
+    """
+
+    stub:
+    """
+    touch ${sample}.variants.vcf
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,13 @@ process {
         time = '4h'
     }
     
-    withName: CALL_VARIANTS {
+    withName: CALL_VARIANTS_LONG {
+        cpus = 8
+        memory = '8 GB'
+        time = '2h'
+    }
+
+    withName: CALL_VARIANTS_SHORT {
         cpus = 8
         memory = '8 GB'
         time = '2h'

--- a/read_alignment_pipeline.nf
+++ b/read_alignment_pipeline.nf
@@ -16,6 +16,31 @@ params.referenceFasta = "./reference/H37Rv.fasta"
 params.outputPrefix = "MTB_consensus"
 params.readType = null
 
+// Validate required parameters
+if (!params.readType) {
+    error """
+    ERROR: --readType parameter is required!
+    
+    Please specify either:
+      --readType short    (for Illumina/short reads)
+      --readType long     (for Nanopore/long reads)
+    
+    Example:
+      nextflow run read_alignment_pipeline.nf --readType short --inputFastq ./data --referenceFasta ./ref.fasta --outputPrefix sample1
+    """.stripIndent()
+}
+
+if (!(params.readType in ['short', 'long'])) {
+    error """
+    ERROR: Invalid readType '${params.readType}'
+    
+    Valid options are:
+      --readType short
+      --readType long
+    """.stripIndent()
+}
+
+
 workflow {
     // Channels
     ch_reference = Channel.fromPath(params.referenceFasta).first() // Allows running multiple fastqs with the same reference

--- a/read_alignment_pipeline.nf
+++ b/read_alignment_pipeline.nf
@@ -5,7 +5,8 @@ nextflow.enable.dsl=2
 
 // Include modules
 include { ALIGN } from './modules/align.nf'
-include { CALL_VARIANTS } from './modules/variants.nf'
+include { CALL_VARIANTS_LONG } from './modules/variants_long.nf'
+include { CALL_VARIANTS_SHORT } from './modules/variants_short.nf'
 include { GENERATE_CONSENSUS } from './modules/consensus.nf'
 
 // Define parameters for input and output paths
@@ -13,22 +14,29 @@ params.inputFastq = "./fastq_files"
 params.outputDir = "./results"
 params.referenceFasta = "./reference/H37Rv.fasta"
 params.outputPrefix = "MTB_consensus"
+params.readType = null
 
 workflow {
     // Channels
     ch_reference = Channel.fromPath(params.referenceFasta).first() // Allows running multiple fastqs with the same reference
+
+    if (params.readType == 'short') {
+        ch_fastq = Channel.fromFilePairs("${params.inputFastq}/*_{1,2}.{fastq.gz}", 
+                                        size: 2, flat: false)
+                         .ifEmpty { error "No paired-end FASTQ files found in ${params.inputFastq}. Expected pattern: *_1.fastq.gz/*_2.fastq.gz" }
+    } else if (params.readType == 'long') {
     ch_fastq = Channel.fromPath("${params.inputFastq}/*.fastq.gz")
                      .map { file -> tuple(file.simpleName, file) }
+    }
 
-    // Debug output
-    ch_fastq.view { sample, file -> "Processing: ${sample}" }
-
-    // Align reads to the assembled reference using minimap2
+    // Align reads to the reference genome using minimap2 for both long and short reads
     ALIGN(ch_reference, ch_fastq)
 
-    // Call variants with longshot, producing a VCF
-    CALL_VARIANTS(ALIGN.out.bam, ch_reference)
+    // Call variants using longshot for long reads and freebayes for short reads
+    ch_variants = params.readType == 'long' ? 
+        CALL_VARIANTS_LONG(ALIGN.out.bam, ch_reference) : 
+        CALL_VARIANTS_SHORT(ALIGN.out.bam, ch_reference)
 
-    // Generate consensus sequence from the VCF and reference files
-    GENERATE_CONSENSUS(CALL_VARIANTS.out.vcf, ch_reference)
+    // Generate consensus sequences from the called variants and reference
+    GENERATE_CONSENSUS(ch_variants.vcf, ch_reference)
 }


### PR DESCRIPTION
Add paired end short read processing to MVP long read pipeline. Both long reads and short reads are being aligned using minimap2, with appropriate settings. Freebayes is used for short read variant calling. 